### PR TITLE
fix: remove basePath to make profile image accessible at root URL

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,8 +6,6 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
-  assetPrefix: process.env.NODE_ENV === 'production' ? '/MyActivity/' : '',
-  basePath: process.env.NODE_ENV === 'production' ? '/MyActivity' : '',
 };
 
 export default nextConfig;


### PR DESCRIPTION
Remove basePath and assetPrefix configurations from next.config.ts to deploy the site to the root GitHub Pages domain instead of /MyActivity/ subdirectory.

This fixes the 404 error when accessing https://ryosukedtomita.github.io/images/profile.jpg

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)