### PR TITLE
fix: resolve Tailwind CSS v4 build conflicts

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};


### PR DESCRIPTION
Fixes build errors caused by conflicting PostCSS configurations.

Removed the old `postcss.config.js` file that was conflicting with the new `postcss.config.mjs` configuration required for Tailwind CSS v4.

This resolves the build errors and allows the site to display properly.

Fixes #15

Generated with [Claude Code](https://claude.ai/code)