### PR TITLE
fix: resolve GitHub Pages JS 404 errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: 'export',
   trailingSlash: true,
+  basePath: '/MyActivity',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
Fixes #17

This PR resolves the JavaScript 404 errors on GitHub Pages by adding the missing `basePath` configuration to Next.js.

## Changes
- Added `basePath: '/MyActivity'` to `next.config.ts`

This ensures that JavaScript and CSS files are served from the correct path when deployed to GitHub Pages.

Generated with [Claude Code](https://claude.ai/code)