### PR TITLE
fix: update Tailwind CSS import syntax for v4 compatibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 :root {
   --background: #ffffff;


### PR DESCRIPTION
Fixes #19

Updated globals.css to use Tailwind CSS v4 import syntax.

## Changes
- Updated `@tailwind base;`, `@tailwind components;`, `@tailwind utilities;` to `@import "tailwindcss";`

This resolves the CSS not being applied issue by using the correct syntax for Tailwind v4.

Generated with [Claude Code](https://claude.ai/code)