### PR TITLE
fix: correct profile image path for GitHub Pages deployment

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ const profile = {
   title: "Security Engineer",
   description: "NRI SecureTechnologies でセキュリティエンジニアとして活動。DevSecOps、セキュリティ診断、生成AI活用推進に従事。Qiitaに100件以上の技術記事を投稿し、勉強会でのLTも実施。",
   location: "Tokyo, Japan",
-  avatar: "/images/profile.jpg", // ここを実際の画像パスに変更してください
+  avatar: "./images/profile.jpg", // ここを実際の画像パスに変更してください
   joinDate: "2022年",
   links: [
     {


### PR DESCRIPTION
Fixes #21

This PR resolves the profile image display issue where the image was returning a 404 error.

## Changes
- Changed avatar path from absolute `/images/profile.jpg` to relative `./images/profile.jpg`
- Ensures proper compatibility with Next.js `basePath: '/MyActivity'` configuration
- Image should now resolve correctly to: `https://ryosukedtomita.github.io/MyActivity/images/profile.jpg`

Generated with [Claude Code](https://claude.ai/code)